### PR TITLE
use NODE_ENV=test and add .resi in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,49 +43,62 @@ And add the PPX in your `bsconfig.json` file:
 
 1. Install the testing framework of your choice (like [jest](https://github.com/glennsl/rescript-jest), [zora](https://github.com/dusty-phillips/rescript-zora), [rescript-test](https://github.com/bloodyowl/rescript-test) or other)
 2. Write some inline tests:
-    ```rescript
-    // Math.res
-    let sum = (a, b) => {
-      a + b
-    }
-    
-    @inline_test
-    Jest.test("adds 1 + 2 to equal 3", () => {
-      expect(sum(1, 2)).toBe(3);
-    });
-    ```
-    > Note: our PPX assumes that the testing framework is designed similarly to jest or zora. I.e. that tests are simply defined as top level expressions in arbitrary files. At the time of writing this readme we are not aware of testing frameworks for rescript that are designed differently.
+
+   ```rescript
+   // Math.res
+   let sum = (a, b) => {
+     a + b
+   }
+
+   @inline_test
+   Jest.test("adds 1 + 2 to equal 3", () => {
+     expect(sum(1, 2)).toBe(3);
+   });
+   ```
+
+   > Note: our PPX assumes that the testing framework is designed similarly to jest or zora. I.e. that tests are simply defined as top level expressions in arbitrary files. At the time of writing this readme we are not aware of testing frameworks for rescript that are designed differently.
+
 3. Make test runner aware of the tests. All tests are indirectly accessible through `lib/bs/__inline_test.*`:
+
    ### Jest
+
    In your jest config
+
    ```
    testMatch: [
      "lib/bs/__inline_test.*.cjs", // use .mjs if you have es6 output configured in bsconfig
      // other test locations ...
    ]
    ```
+
    ### Zora (with pta):
+
    ```
    // scripts in package.json
-   "test": "pta 'lib/bs/__inline_test.*.cjs'" // add other locations as you see fit
+   "test": "NODE_ENV=test pta 'lib/bs/__inline_test.*.cjs'" // add other locations as you see fit
    ```
+
+   Please note that in order for tests to be run, `NODE_ENV` has to be set to `test`, which is done by default by Jest but not by some other frameworks.
+
    ### Others
+
    Other frameworks usually have similar configurations which allow you to point to the location of JavaScript files containing case. In the case of our ppx all tests are referenced by artifacts located in `lib/bs/` prefixed with `__inline_test`.
+
 4. Compile your sources with `INLINE_TEST=1` to compile the tests
-    ```
-    // scripts in package.json
-    "watch": "INLINE_TEST=1 rescript build  -with-deps -w"
-    ```
-    #### Caveat
-    Beaware that now all of the modules which contain inline tests will have inline tests present in `.js` artifacts. If you run:
-    ```
-    INLINE_TEST=0 yarn rescript build
-    ```
-    your modules **will not** be recompiled. In order to get rid of the testing code in js files clean the project first using:
-    ```
-    yarn rescript clean
-    ```
-    and then recompile them with the `INLINE_TEST` environment variable simply undefined or defined as `0` or `false`.
+   ```
+   // scripts in package.json
+   "watch": "INLINE_TEST=1 rescript build  -with-deps -w"
+   ```
+   #### Caveat
+   Beaware that now all of the modules which contain inline tests will have inline tests present in `.js` artifacts. If you run:
+   ```
+   INLINE_TEST=0 yarn rescript build
+   ```
+   your modules **will not** be recompiled. In order to get rid of the testing code in js files clean the project first using:
+   ```
+   yarn rescript clean
+   ```
+   and then recompile them with the `INLINE_TEST` environment variable simply undefined or defined as `0` or `false`.
 
 ## How it works
 

--- a/project_sample/package.json
+++ b/project_sample/package.json
@@ -5,7 +5,7 @@
       "build": "rescript",
       "clean": "rescript clean -with-deps",
       "start": "INLINE_TEST=1 rescript build -w",
-      "test": "pta lib/bs/__inline_test.*.*"
+      "test": "NODE_ENV=test pta lib/bs/__inline_test.*.*"
     },
     "keywords": [
       "rescript"

--- a/project_sample/src/Demo.res
+++ b/project_sample/src/Demo.res
@@ -6,3 +6,5 @@ Zora.zora("sum", t => {
   t->equal(sum(1, 2), 3, "simple test: 1 + 2 = 3")
   done()
 })
+
+let foo = sum(1, 2)

--- a/project_sample/src/Demo.resi
+++ b/project_sample/src/Demo.resi
@@ -1,0 +1,6 @@
+/*
+    notice how we can write tests for private functions 
+    that are not even exported
+*/
+
+let foo: int


### PR DESCRIPTION
Zora needs NODE_ENV=test when running tests, so I added it both in the README and the project sample.

I also added a .resi file in the project sampel to showcase how you can test private functions thanks to our PPX.